### PR TITLE
IPipeState does not take into account collection size

### DIFF
--- a/dist/paginate-pipe.js
+++ b/dist/paginate-pipe.js
@@ -79,6 +79,7 @@ var PaginatePipe = (function () {
      */
     PaginatePipe.prototype.saveState = function (id, collection, slice, start, end) {
         this.state[id] = {
+            size: collection.length,
             collection: collection,
             slice: slice,
             start: start,
@@ -93,7 +94,10 @@ var PaginatePipe = (function () {
         if (!state) {
             return false;
         }
-        return state.collection === collection && state.start === start && state.end === end;
+        return state.collection === collection &&
+            state.size === collection.length &&
+            state.start === start &&
+            state.end === end;
     };
     PaginatePipe = __decorate([
         core_1.Pipe({

--- a/src/paginate-pipe.spec.ts
+++ b/src/paginate-pipe.spec.ts
@@ -143,5 +143,24 @@ describe('paginate pipe', () => {
         });
     });
 
+    describe('collection modification', () => {
+
+        it('should detect simple push or splice without insert', () => {
+            collection = ['1', '2', '3'];
+
+            let result1 = pipe.transform(collection, ['10']);
+            expect(result1.length).toBe(3);
+
+            collection.push('4');
+
+            let result2 = pipe.transform(collection, ['10']);
+            expect(result2.length).toBe(4);
+
+            collection.splice(3, 1); // remove 4th
+
+            let result3 = pipe.transform(collection, ['10']);
+            expect(result3.length).toBe(3);
+        });
+    });
 
 });

--- a/src/paginate-pipe.ts
+++ b/src/paginate-pipe.ts
@@ -6,6 +6,7 @@ const LARGE_NUMBER = 999999999;
 
 interface IPipeState {
     collection: any[];
+    size: number;
     start: number;
     end: number;
     slice: any[];
@@ -90,6 +91,7 @@ export class PaginatePipe {
      */
     private saveState(id: string, collection: any[], slice: any[], start: number, end: number) {
         this.state[id] = {
+            size: collection.length,
             collection,
             slice,
             start,
@@ -106,6 +108,9 @@ export class PaginatePipe {
             return false;
         }
 
-        return state.collection === collection && state.start === start && state.end === end;
+        return state.collection === collection &&
+            state.size === collection.length &&
+            state.start === start &&
+            state.end === end;
     }
 }


### PR DESCRIPTION
Please, consider the following example:


```typescript
import { Component } from 'angular2/core';

import { PaginatePipe, PaginationControlsCmp, PaginationService } from 'ng2-pagination';

@Component({
    selector: 'items-list',
    templateUrl: 'template.jade',
    directives: [PaginationControlsCmp],
    pipes: [PaginatePipe],
    providers: [PaginationService]
})
export class ItemsList {
    items = ['1', '2', '3'];

    deleteItem(item: string) {
        this.items.splice(this.items.indexOf(item), 1);
    }
}
```

template.jade:
```jade
div('*ngFor'='#item of items | paginate:10')
	a('(click)'='deleteItem(item)') Delete
```

When I press "Delete" button, the collection does not get re-transformed, since in stateIsIdentical there's no check for it's size, only for start/end. This PR adds collection size to the IPipeState.

Although, the size check will handle simple changes like push/pop/shift/unshift and splice (when it does change the size of the collection), it will not detect things like this: ```collection.splice(1, 1, 1);``` and I don't really know what will.