### PR TITLE
Fix https://github.com/michaelbromley/ng2-pagination/issues/35

### DIFF
--- a/src/paginate-pipe.spec.ts
+++ b/src/paginate-pipe.spec.ts
@@ -93,6 +93,27 @@ describe('PaginatePipe:', () => {
 
             expect(result4.length).toBe(2);
         });
+
+        it('should detect value changes in collection', () => {
+
+            let config = {
+                itemsPerPage: 10,
+                currentPage: 1
+            };
+
+            collection = ['not changed', '2', '3'];
+
+            pipe.transform(collection, [config]);
+
+            let changed = 'changed';
+
+            collection[0] = changed;
+
+            let result2 = pipe.transform(collection, [config]);
+
+            expect(result2[0]).toBe(changed)
+
+        });
     });
 
     it('should allow independent instances by setting an id', () => {

--- a/src/paginate-pipe.ts
+++ b/src/paginate-pipe.ts
@@ -123,9 +123,15 @@ export class PaginatePipe {
         if (!state) {
             return false;
         }
-        return state.collection === collection &&
+        let isMetaDataIdentical = state.collection === collection &&
             state.size === collection.length &&
             state.start === start &&
             state.end === end;
+
+        if(!isMetaDataIdentical) {
+            return false;
+        }
+
+        return state.slice.every((element, index) => element === collection[start + index]);
     }
 }


### PR DESCRIPTION
Hi,

I had the same issue like https://github.com/michaelbromley/ng2-pagination/issues/35. 
The problem is that the view gets only updated if some collection metadata changes. If you just change a value in the collection the change will not be recognized.

This PR fixes the issue by comparing every element in the state slice with the corresponding element in the collection.

PSanetra