### PR TITLE
Fixed concatenation error

### DIFF
--- a/src/paginate-pipe.ts
+++ b/src/paginate-pipe.ts
@@ -52,6 +52,7 @@ export class PaginatePipe {
 
         if (!serverSideMode && collection instanceof Array) {
             perPage = perPage || LARGE_NUMBER;
+            perPage = +perPage; // convert to number; avoid concatenation when calculating 'end'
             start = (instance.currentPage - 1) * perPage;
             end = start + perPage;
 


### PR DESCRIPTION
I adjust `itemsPerPage` dynamically via select box. While using the initial value everything was fine. But after changing `itemsPerPage`, the new `perPage` value was a string. So the result of `end = start + perPage` was much too high on any page other than `1`.