### PR TITLE
Change DemoModuleNgFactory to DemoModule

### DIFF
--- a/demo/src/bootstrap.aot.ts
+++ b/demo/src/bootstrap.aot.ts
@@ -1,7 +1,7 @@
 import 'reflect-metadata';
 import {enableProdMode} from '@angular/core';
-import {platformBrowser} from '@angular/platform-browser';
-import {DemoModuleNgFactory} from '../ngfactory/demo/src/demo.module.ngfactory';
+import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
+import {DemoModule} from './demo.module';
 
 enableProdMode();
-platformBrowser().bootstrapModuleFactory(DemoModuleNgFactory);
+platformBrowserDynamic().bootstrapModule(DemoModule);


### PR DESCRIPTION
Bug Fix
When npm run demo:watch

I have this error,

ERROR in /Users/mahmutduva/Desktop/myProjects/ng2-pagination/demo/src/bootstrap.aot.ts
(4,35): error TS2307: Cannot find module '../ngfactory/demo/src/demo.module.ngfactory'.
